### PR TITLE
feat: add zod form validation

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "@connectrpc/connect-query": "0.8.0",
     "@mui/material": "5.15.14",
     "@emotion/react": "11.11.3",
-    "@emotion/styled": "11.11.3"
+    "@emotion/styled": "11.11.3",
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "typescript": "5.2.2"

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { z } from 'zod';
 import { createPromiseClient } from '@connectrpc/connect';
 import { createConnectTransport } from '@connectrpc/connect-web';
 import { TextField, Button, Box, Typography } from '@mui/material';
@@ -10,18 +11,34 @@ type Props = { publicMsg: string };
 export default function Home({ publicMsg }: Props) {
   const [token, setToken] = useState('');
   const [secret, setSecret] = useState('');
+  const [errors, setErrors] = useState<{ username?: string; password?: string }>({});
 
   const transport = createConnectTransport({
     baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080',
   });
   const client = createPromiseClient(AuthService, transport);
 
+  const loginSchema = z.object({
+    username: z.string().min(1, 'Username is required'),
+    password: z.string().min(1, 'Password is required'),
+  });
+
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault();
     const form = e.target as HTMLFormElement;
     const username = (form.elements.namedItem('username') as HTMLInputElement).value;
     const password = (form.elements.namedItem('password') as HTMLInputElement).value;
-    const res = await client.login({ username, password });
+    const result = loginSchema.safeParse({ username, password });
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setErrors({
+        username: fieldErrors.username?.[0],
+        password: fieldErrors.password?.[0],
+      });
+      return;
+    }
+    setErrors({});
+    const res = await client.login(result.data);
     setToken(res.token);
   }
 
@@ -40,8 +57,8 @@ export default function Home({ publicMsg }: Props) {
         Login
       </Typography>
       <Box component="form" onSubmit={handleLogin} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <TextField name="username" label="Username" />
-        <TextField name="password" type="password" label="Password" />
+        <TextField name="username" label="Username" error={!!errors.username} helperText={errors.username} />
+        <TextField name="password" type="password" label="Password" error={!!errors.password} helperText={errors.password} />
         <Button type="submit" variant="contained">Login</Button>
       </Box>
       <Button onClick={callSecret} sx={{ mt: 2 }} variant="outlined">


### PR DESCRIPTION
## Summary
- add zod dependency
- validate login form fields with zod and show errors

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_688f6758a10c832ca0a1fee54ded96e2