### PR TITLE
chore: add taskfile for common dev workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This repository contains the **Utro** full stack application for [inspirationpar
 
 ## Usage
 
+This repository includes a [Taskfile](https://taskfile.dev) to streamline common
+development tasks. After installing Task, you can run:
+
+```bash
+task proto   # Generate protobuf code
+task api     # Run the Spring Boot backend
+task web     # Run the Next.js frontend
+task docker  # Build images and run Docker Compose
+task k8s     # Apply Kubernetes manifests
+```
+
 Generate protobuf code:
 
 ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+vars:
+  BACKEND_DIR: api/app
+  FRONTEND_DIR: web
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task -l
+    silent: true
+
+  proto:
+    desc: Generate protobuf code
+    cmds:
+      - buf generate
+
+  api:
+    desc: Run Spring Boot backend
+    dir: "{{.BACKEND_DIR}}"
+    cmds:
+      - mvn spring-boot:run
+
+  web:
+    desc: Run Next.js frontend
+    dir: "{{.FRONTEND_DIR}}"
+    cmds:
+      - npm install
+      - npm run dev
+
+  docker:
+    desc: Build images and run with Docker Compose
+    cmds:
+      - docker compose up --build
+
+  k8s:
+    desc: Apply Kubernetes manifests
+    cmds:
+      - kubectl apply -f k8s/api-deployment.yaml
+      - kubectl apply -f k8s/web-deployment.yaml


### PR DESCRIPTION
## Summary
- add Taskfile with commands for generating protobufs, running app services, Docker Compose, and Kubernetes
- document Taskfile usage in README

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: network is unreachable)*
- `npm test` *(fails: Missing script "test")*
- `task -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6fba7674832c9cdafcaa93658a9a