### PR TITLE
Add OAuth2 resource server dependency

### DIFF
--- a/api/app/pom.xml
+++ b/api/app/pom.xml
@@ -34,6 +34,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
         <dependency>
@@ -59,10 +63,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>4.31.1</version>
-    </dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>4.31.1</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Summary
- Include Spring Boot OAuth2 resource server starter to supply BearerTokenResolver
- Clean up protobuf dependency formatting

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f91a6d790832c943d3322f8ff420e