### PR TITLE
Define JwtDecoder bean in SecurityConfig

### DIFF
--- a/api/app/src/main/java/com/inspirationparticle/utro/security/SecurityConfig.java
+++ b/api/app/src/main/java/com/inspirationparticle/utro/security/SecurityConfig.java
@@ -1,10 +1,17 @@
 package com.inspirationparticle.utro.security;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 
 @Configuration
 @EnableMethodSecurity
@@ -21,5 +28,11 @@ public class SecurityConfig {
             .formLogin(form -> {})
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> {}));
         return http.build();
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(@Value("${jwt.secret}") String secret) {
+        SecretKey key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(key).build();
     }
 }

--- a/api/app/src/main/resources/application.yml
+++ b/api/app/src/main/resources/application.yml
@@ -10,6 +10,8 @@ spring:
               - openid
               - profile
               - email
+jwt:
+  secret: change-me
 server:
   port: 8080
 management:


### PR DESCRIPTION
## Summary
- add JwtDecoder bean built from configurable HMAC secret
- add jwt.secret property to application configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for app due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f9659b32c832c99aea514ed98dae2