### PR TITLE
fix: run proto task in correct directory

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,7 @@ tasks:
 
   proto:
     desc: Generate protobuf code
+    dir: proto
     cmds:
       - buf generate
 


### PR DESCRIPTION
## Summary
- ensure `task proto` runs inside `proto` so `buf.gen.yaml` is found

## Testing
- `task proto`


------
https://chatgpt.com/codex/tasks/task_e_688f9d1542e8832cbb24475ca8308953